### PR TITLE
fix: wrap longitude coordinates to within 180 degrees

### DIFF
--- a/assets/view.js
+++ b/assets/view.js
@@ -70,6 +70,7 @@ CTFd.plugin.run((_CTFd) => {
         mapInstance = L.map("map-solve", {
           center: [0, 0],
           zoom: 2,
+          worldCopyJump: true,
         });
 
         // Define base layers


### PR DESCRIPTION
Hello,
I have enabled `worldCopyJump` to ensure that longitude coordinates remain within the standard geographical range.

**Problem:** Panning the map multiple times can cause longitude to exceed $\pm180^\circ$. 
This leads to correct answers being judged as Incorrect on the backend because the values fall outside the expected bounds.

- Added `worldCopyJump: true` to the map initialization. (assets/view.js:73)